### PR TITLE
vs_INF

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -69,4 +69,4 @@
   # Sunrise-start
   - type: ClothingSlowOnDamageModifier
     modifier: 0.35
-  # Sunrise-start
+  # Sunrise-end

--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -66,4 +66,6 @@
     containers:
       item:
       - ThrowingKnife
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.35
 

--- a/Resources/Prototypes/Catalog/Fills/Items/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/misc.yml
@@ -66,6 +66,7 @@
     containers:
       item:
       - ThrowingKnife
+  # Sunrise-start
   - type: ClothingSlowOnDamageModifier
     modifier: 0.35
-
+  # Sunrise-start

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -680,6 +680,8 @@
         Radiation: 0.25
         Caustic: 0.25
         Bloodloss: 0.5
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.25
   - type: FireProtection
     reduction: 0.5
   - type: ClothingSlowOnDamageModifier
@@ -720,6 +722,8 @@
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5
+  - type: ZombificationResistance # Sunrise Edit
+    zombificationResistanceCoefficient: 0.6 # Sunrise Edit
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -66,7 +66,7 @@
     ears: ClothingHeadsetAltSyndicate
     gloves: ClothingHandsGlovesCombatCQC
     outerClothing: ClothingOuterHardsuitSyndieBiocode # Sunrise-Edit
-    shoes: ClothingShoesBootsCombatFilled
+    shoes: ClothingShoesBootsSyndieFilled # Sunrise-Edit
     id: SyndiOperativePDA
     pocket2: PlushieCarp
     belt: ClothingBeltMilitaryWebbing
@@ -83,7 +83,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitOperative
     back: ClothingBackpackDuffelSyndicate
-    shoes: ClothingShoesBootsCombatFilled
+    shoes: ClothingShoesBootsSyndieFilled # Sunrise-Edit
     id: SyndiOperativePDA
     pocket1: BaseUplinkRadio0TC # Sunrise-Edit
   storage:


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
<!--
Что вы предлагаете изменить с помощью своего PR?
-->
добавил элитному скафу 40% против инфекции, скафу медика 75%. ну в нынешней момент это выглядит неплохо, ведь с рассказчиком увидеть ЯО+ЗОМБИ - легко. видеть умирающих оперов от 1 укусу не весело. 

оперативник гир изменился, теперь оперы появляются в синди армейских ботинках, а не в обычных. (65% против замедления, метательный нож)
## Ссылка на багрепорт/Предложение
<!--
Ссылки на Дискуссии и Баг-репорты указывать здесь.
-->

## Медиа (Видео/Скриншоты)
<!--
Если ваш PR содержит внутриигровые изменения, вы обязаны предоставить скриншоты/видео изменений.
-->

<!--
## TODO

Не закончили? Добавьте список того, что требуется для завершения PR'а.

- [ ] Task 1
- [ ] Task 2
-->

<!--
## Требования к картам

Если ваше изменение требует изменение на картах - опишите требования тут.
Так мапперы серверов смогут понять, как адаптировать карты под ваши изменения.


-->

**Changelog**

<!--
=== КАК ПИСАТЬ ЧЕЙНЖЛОГ ===

[RU]
1) Не считайте тип чейнжлога частью вашего предложения.
add: Новая фича = ПЛОХО | add: Добавлена новая фича = ХОРОШО
2) Подробно описывайте, что вы добавили и как это использовать. Все должно быть в меру.
fix: Исправлены мелочи = УЖАСНО | fix: Исправлена невозможность игроков двигаться = ХОРОШО
3) Не добавляйте технические детали. Чейнжлог пишется для игроков.
add: Добавлен новый хелпер-метод = ПЛОХО | НИЧЕГО НЕ ПИСАТЬ = ХОРОШО
* Иногда чейнжлог не нужен. Просто удалите это поле.

-->

:cl: fuckrules
- tweak: Элитные и медицинские скафандры оперативников получили защиту от инфекций
- tweak: Теперь оперативники появляются в армейских ботинках Синдиката вместо обычных.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Синдикатские ботинки теперь замедляют владельца при получении урона.
  * Медицинский и элитный синдикатские скафандры получили устойчивость к зомбированию с разной эффективностью.
  * Снаряжение оперативников синдиката теперь включает улучшенные синдикатские ботинки вместо боевых.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->