### PR TITLE
Фикс спавна червей плоти на СЦК и иных событий

### DIFF
--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using Content.Server._Sunrise.StationEvents;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;
@@ -7,7 +7,6 @@ using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
 using Content.Shared.Database;
 using Content.Shared.GameTicking.Components;
-using Content.Shared.Station.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -51,8 +50,8 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (stationEvent.StartAnnouncement != null)
             ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
                 Loc.GetString(stationEvent.StartAnnouncement),
-                playDefault: false,
-                announcementSound: stationEvent.StartAudio,
+                playDefault: false, // Sunrise-Edit
+                announcementSound: stationEvent.StartAudio, // Sunrise-Edit
                 colorOverride: stationEvent.StartAnnouncementColor);
         else
         {
@@ -101,8 +100,8 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (stationEvent.EndAnnouncement != null)
             ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
                 Loc.GetString(stationEvent.EndAnnouncement),
-                playDefault: false,
-                announcementSound: stationEvent.EndAudio,
+                playDefault: false, // Sunrise-Edit
+                announcementSound: stationEvent.EndAudio, // Sunrise-Edit
                 colorOverride: stationEvent.EndAnnouncementColor);
         else
         {
@@ -129,28 +128,15 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             if (!GameTicker.IsGameRuleAdded(uid, ruleData))
                 continue;
 
-            // Sunrise-Start: Исключаем ЦентКом из станционных событий
             if (!GameTicker.IsGameRuleActive(uid, ruleData) && !HasComp<DelayedStartRuleComponent>(uid))
             {
-                // Проверяем, не является ли целевая станция ЦентКомом
-                var targetStation = StationSystem.GetStations()
-                    .FirstOrDefault(station =>
-                    {
-                        if (!TryComp<StationDataComponent>(station, out var data))
-                            return false;
-
-                        if (data.StationConfig != null && data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
-                            return false;
-
-                        return true;
-                    });
-
-                if (!targetStation.IsValid())
+                // Sunrise edit start - проверка доступности игровой станции (исключая ЦентКом)
+                if (StationEventHelper.ShouldSkipEvent(uid, StationSystem, EntityManager, Sawmill))
                 {
-                    Sawmill.Info($"Skipping event {ToPrettyString(uid)}: no valid target station");
                     GameTicker.EndGameRule(uid, ruleData);
                     continue;
                 }
+                // Sunrise edit end
 
                 GameTicker.StartGameRule(uid, ruleData);
             }
@@ -158,7 +144,6 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             {
                 GameTicker.EndGameRule(uid, ruleData);
             }
-            // Sunrise-End
         }
     }
 }

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
-// Sunrise edit start - added helper for CentComm exclusion
+// Sunrise edit start - добавлен помощник для исключения ЦентКома
 using Content.Server._Sunrise.StationEvents;
 // Sunrise edit end
 
@@ -46,9 +46,11 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (!TryComp<StationEventComponent>(uid, out var stationEvent))
             return;
 
-        // Sunrise edit start - check for valid player station before announcing
+        // Sunrise edit start - проверка доступной станции перед анонсом
         if (StationEventHelper.ShouldSkipEvent(uid, StationSystem, EntityManager, Sawmill))
         {
+            // Если нет доступной станции - отменяем правило без анонса
+            GameTicker.EndGameRule(uid, gameRule);
             return;
         }
         // Sunrise edit end
@@ -140,11 +142,13 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             if (!GameTicker.IsGameRuleAdded(uid, ruleData))
                 continue;
 
-            // Sunrise edit start - check for valid player station before starting
+            // Sunrise edit start - проверка доступной станции перед запуском
             if (!GameTicker.IsGameRuleActive(uid, ruleData) && !HasComp<DelayedStartRuleComponent>(uid))
             {
                 if (StationEventHelper.ShouldSkipEvent(uid, StationSystem, EntityManager, Sawmill))
                 {
+                    // Правило уже должно быть отменено в Added()
+                    // Завершаем без анонса
                     GameTicker.EndGameRule(uid, ruleData);
                     continue;
                 }

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
-// Sunrise edit start - добавлен помощник для исключения ЦентКома
+// Sunrise edit start - добавлен помощник для проверки игровой станции
 using Content.Server._Sunrise.StationEvents;
 // Sunrise edit end
 
@@ -30,12 +30,14 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
     [Dependency] protected readonly StationSystem StationSystem = default!;
 
     protected ISawmill Sawmill = default!;
+    private EntityQuery<DelayedStartRuleComponent> _delayedStartQuery;
 
     public override void Initialize()
     {
         base.Initialize();
 
         Sawmill = Logger.GetSawmill("stationevents");
+        _delayedStartQuery = GetEntityQuery<DelayedStartRuleComponent>();
     }
 
     /// <inheritdoc/>
@@ -46,11 +48,11 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (!TryComp<StationEventComponent>(uid, out var stationEvent))
             return;
 
-        // Sunrise edit start - проверка доступной станции перед анонсом
-        if (StationEventHelper.ShouldSkipEvent(uid, StationSystem, EntityManager, Sawmill))
+        // Sunrise edit start - удаление события, если нет игровой станции
+        if (!StationEventHelper.HasValidPlayerStation(StationSystem, EntityManager))
         {
-            // Если нет доступной станции - отменяем правило без анонса
-            GameTicker.EndGameRule(uid, gameRule);
+            Sawmill.Info($"Событие {ToPrettyString(uid)} удалено: нет игровой станции");
+            QueueDel(uid);
             return;
         }
         // Sunrise edit end
@@ -142,24 +144,14 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             if (!GameTicker.IsGameRuleAdded(uid, ruleData))
                 continue;
 
-            // Sunrise edit start - проверка доступной станции перед запуском
-            if (!GameTicker.IsGameRuleActive(uid, ruleData) && !HasComp<DelayedStartRuleComponent>(uid))
+            if (!GameTicker.IsGameRuleActive(uid, ruleData) && !_delayedStartQuery.HasComponent(uid))
             {
-                if (StationEventHelper.ShouldSkipEvent(uid, StationSystem, EntityManager, Sawmill))
-                {
-                    // Правило уже должно быть отменено в Added()
-                    // Завершаем без анонса
-                    GameTicker.EndGameRule(uid, ruleData);
-                    continue;
-                }
-
                 GameTicker.StartGameRule(uid, ruleData);
             }
             else if (stationEvent.EndTime != null && Timing.CurTime >= stationEvent.EndTime && GameTicker.IsGameRuleActive(uid, ruleData))
             {
                 GameTicker.EndGameRule(uid, ruleData);
             }
-            // Sunrise edit end
         }
     }
 }

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -51,7 +51,7 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         // Sunrise edit start - удаление события, если нет игровой станции
         if (!StationEventHelper.HasValidPlayerStation(StationSystem, EntityManager))
         {
-            Sawmill.Info($"Событие {ToPrettyString(uid)} удалено: нет игровой станции");
+            Sawmill.Info($"Event {ToPrettyString(uid)} removed: no player station available");
             QueueDel(uid);
             return;
         }
@@ -144,9 +144,21 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             if (!GameTicker.IsGameRuleAdded(uid, ruleData))
                 continue;
 
-            if (!GameTicker.IsGameRuleActive(uid, ruleData) && !_delayedStartQuery.HasComponent(uid))
+            if (!GameTicker.IsGameRuleActive(uid, ruleData))
             {
-                GameTicker.StartGameRule(uid, ruleData);
+                // Sunrise edit start - проверка станции для всех неактивных правил (включая delayed)
+                if (!StationEventHelper.HasValidPlayerStation(StationSystem, EntityManager))
+                {
+                    Sawmill.Info($"Event {ToPrettyString(uid)} removed before start: no player station available");
+                    QueueDel(uid);
+                    continue;
+                }
+                // Sunrise edit end
+
+                if (!_delayedStartQuery.HasComponent(uid))
+                {
+                    GameTicker.StartGameRule(uid, ruleData);
+                }
             }
             else if (stationEvent.EndTime != null && Timing.CurTime >= stationEvent.EndTime && GameTicker.IsGameRuleActive(uid, ruleData))
             {

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -1,4 +1,4 @@
-using Content.Server._Sunrise.StationEvents;
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;
@@ -7,9 +7,14 @@ using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
 using Content.Shared.Database;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+
+// Sunrise edit start - added helper for CentComm exclusion
+using Content.Server._Sunrise.StationEvents;
+// Sunrise edit end
 
 namespace Content.Server.StationEvents.Events;
 
@@ -41,6 +46,13 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (!TryComp<StationEventComponent>(uid, out var stationEvent))
             return;
 
+        // Sunrise edit start - check for valid player station before announcing
+        if (StationEventHelper.ShouldSkipEvent(uid, StationSystem, EntityManager, Sawmill))
+        {
+            return;
+        }
+        // Sunrise edit end
+
         AdminLogManager.Add(LogType.EventAnnounced, $"Event added / announced: {ToPrettyString(uid)}");
 
         // we don't want to send to players who aren't in game (i.e. in the lobby)
@@ -50,8 +62,8 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (stationEvent.StartAnnouncement != null)
             ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
                 Loc.GetString(stationEvent.StartAnnouncement),
-                playDefault: false, // Sunrise-Edit
-                announcementSound: stationEvent.StartAudio, // Sunrise-Edit
+                playDefault: false,
+                announcementSound: stationEvent.StartAudio,
                 colorOverride: stationEvent.StartAnnouncementColor);
         else
         {
@@ -100,8 +112,8 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (stationEvent.EndAnnouncement != null)
             ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
                 Loc.GetString(stationEvent.EndAnnouncement),
-                playDefault: false, // Sunrise-Edit
-                announcementSound: stationEvent.EndAudio, // Sunrise-Edit
+                playDefault: false,
+                announcementSound: stationEvent.EndAudio,
                 colorOverride: stationEvent.EndAnnouncementColor);
         else
         {
@@ -128,15 +140,14 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             if (!GameTicker.IsGameRuleAdded(uid, ruleData))
                 continue;
 
+            // Sunrise edit start - check for valid player station before starting
             if (!GameTicker.IsGameRuleActive(uid, ruleData) && !HasComp<DelayedStartRuleComponent>(uid))
             {
-                // Sunrise edit start - проверка доступности игровой станции (исключая ЦентКом)
                 if (StationEventHelper.ShouldSkipEvent(uid, StationSystem, EntityManager, Sawmill))
                 {
                     GameTicker.EndGameRule(uid, ruleData);
                     continue;
                 }
-                // Sunrise edit end
 
                 GameTicker.StartGameRule(uid, ruleData);
             }
@@ -144,6 +155,7 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             {
                 GameTicker.EndGameRule(uid, ruleData);
             }
+            // Sunrise edit end
         }
     }
 }

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking;
@@ -6,6 +7,7 @@ using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Components;
 using Content.Shared.Database;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -49,8 +51,8 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (stationEvent.StartAnnouncement != null)
             ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
                 Loc.GetString(stationEvent.StartAnnouncement),
-                playDefault: false, // Sunrise-Edit
-                announcementSound: stationEvent.StartAudio, // Sunrise-Edit
+                playDefault: false,
+                announcementSound: stationEvent.StartAudio,
                 colorOverride: stationEvent.StartAnnouncementColor);
         else
         {
@@ -99,8 +101,8 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
         if (stationEvent.EndAnnouncement != null)
             ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
                 Loc.GetString(stationEvent.EndAnnouncement),
-                playDefault: false, // Sunrise-Edit
-                announcementSound: stationEvent.EndAudio, // Sunrise-Edit
+                playDefault: false,
+                announcementSound: stationEvent.EndAudio,
                 colorOverride: stationEvent.EndAnnouncementColor);
         else
         {
@@ -127,14 +129,36 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             if (!GameTicker.IsGameRuleAdded(uid, ruleData))
                 continue;
 
+            // Sunrise-Start: Исключаем ЦентКом из станционных событий
             if (!GameTicker.IsGameRuleActive(uid, ruleData) && !HasComp<DelayedStartRuleComponent>(uid))
             {
+                // Проверяем, не является ли целевая станция ЦентКомом
+                var targetStation = StationSystem.GetStations()
+                    .FirstOrDefault(station =>
+                    {
+                        if (!TryComp<StationDataComponent>(station, out var data))
+                            return false;
+
+                        if (data.StationConfig != null && data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
+                            return false;
+
+                        return true;
+                    });
+
+                if (!targetStation.IsValid())
+                {
+                    Sawmill.Info($"Skipping event {ToPrettyString(uid)}: no valid target station");
+                    GameTicker.EndGameRule(uid, ruleData);
+                    continue;
+                }
+
                 GameTicker.StartGameRule(uid, ruleData);
             }
             else if (stationEvent.EndTime != null && Timing.CurTime >= stationEvent.EndTime && GameTicker.IsGameRuleActive(uid, ruleData))
             {
                 GameTicker.EndGameRule(uid, ruleData);
             }
+            // Sunrise-End
         }
     }
 }

--- a/Content.Server/_Sunrise/FleshCult/Events/VentFleshWormsRule.cs
+++ b/Content.Server/_Sunrise/FleshCult/Events/VentFleshWormsRule.cs
@@ -17,19 +17,7 @@ public sealed class VentFleshWormsRule : StationEventSystem<VentFleshWormsRuleCo
     {
         base.Started(uid, component, gameRule, args);
 
-        // Исключаем ЦентКом по StationPrototype
-        var targetStation = _stationSystem.GetStations()
-            .FirstOrDefault(station =>
-            {
-                if (!TryComp<StationDataComponent>(station, out var data))
-                    return false;
-
-                // Проверяем StationConfig.StationPrototype
-                if (data.StationConfig != null && data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
-                    return false;
-
-                return true;
-            });
+        var targetStation = _stationSystem.GetStations().FirstOrNull();
 
         if (!TryComp(targetStation, out StationDataComponent? data))
         {

--- a/Content.Server/_Sunrise/FleshCult/Events/VentFleshWormsRule.cs
+++ b/Content.Server/_Sunrise/FleshCult/Events/VentFleshWormsRule.cs
@@ -17,7 +17,19 @@ public sealed class VentFleshWormsRule : StationEventSystem<VentFleshWormsRuleCo
     {
         base.Started(uid, component, gameRule, args);
 
-        var targetStation = _stationSystem.GetStations().FirstOrNull();
+        // Исключаем ЦентКом по StationPrototype
+        var targetStation = _stationSystem.GetStations()
+            .FirstOrDefault(station =>
+            {
+                if (!TryComp<StationDataComponent>(station, out var data))
+                    return false;
+
+                // Проверяем StationConfig.StationPrototype
+                if (data.StationConfig != null && data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
+                    return false;
+
+                return true;
+            });
 
         if (!TryComp(targetStation, out StationDataComponent? data))
         {

--- a/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
+++ b/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
@@ -1,50 +1,28 @@
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
 using Content.Shared.Station.Components;
-using Robust.Shared.GameObjects;
 
 namespace Content.Server._Sunrise.StationEvents;
 
 /// <summary>
-/// Helper class for checking player station availability (excluding CentComm)
+/// Вспомогательный класс для проверки наличия игровой станции (исключая ЦентКом).
 /// </summary>
 public static class StationEventHelper
 {
     /// <summary>
-    /// Determines whether the event should be skipped due to no valid player station being available.
+    /// Проверяет наличие игровой станции (исключая ЦентКом).
     /// </summary>
-    public static bool ShouldSkipEvent(
-        EntityUid uid,
-        StationSystem stationSystem,
-        IEntityManager entityManager,
-        ISawmill sawmill)
+    public static bool HasValidPlayerStation(StationSystem stationSystem, IEntityManager entityManager)
     {
-        if (!HasValidTargetStation(stationSystem, entityManager))
-        {
-            sawmill.Info($"Skipping event {entityManager.ToPrettyString(uid)}: no valid target station (CentComm excluded)");
-            return true;
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Checks whether a valid player station (excluding CentComm) exists.
-    /// </summary>
-    public static bool HasValidTargetStation(StationSystem stationSystem, IEntityManager entityManager)
-    {
-        var stations = stationSystem.GetStations();
-
-        foreach (var station in stations)
+        foreach (var station in stationSystem.GetStations())
         {
             if (!entityManager.TryGetComponent<StationDataComponent>(station, out var data))
                 continue;
 
-            // Skip stations without config
             if (data.StationConfig is null)
                 continue;
 
-            // Exclude CentComm by StationPrototype
+            // ЦентКом не считается игровой станцией
             if (data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
                 continue;
 

--- a/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
+++ b/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
@@ -1,28 +1,18 @@
-using Content.Server.GameTicking;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
-using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
 using Robust.Shared.GameObjects;
 
 namespace Content.Server._Sunrise.StationEvents;
 
 /// <summary>
-/// Вспомогательный класс для проверки доступности игровой станции (исключая ЦентКом)
+/// Helper class for checking player station availability (excluding CentComm)
 /// </summary>
 public static class StationEventHelper
 {
-    private static EntityUid _cachedStation = EntityUid.Invalid;
-    private static bool _cacheValid;
-
     /// <summary>
-    /// Проверяет, нужно ли пропустить событие из-за отсутствия доступной игровой станции
+    /// Determines whether the event should be skipped due to no valid player station being available.
     /// </summary>
-    /// <param name="uid">Идентификатор события</param>
-    /// <param name="stationSystem">Система станций</param>
-    /// <param name="entityManager">Менеджер сущностей</param>
-    /// <param name="sawmill">Логгер</param>
-    /// <returns>true, если событие нужно пропустить</returns>
     public static bool ShouldSkipEvent(
         EntityUid uid,
         StationSystem stationSystem,
@@ -39,16 +29,10 @@ public static class StationEventHelper
     }
 
     /// <summary>
-    /// Проверяет наличие доступной игровой станции (не ЦентКом)
+    /// Checks whether a valid player station (excluding CentComm) exists.
     /// </summary>
-    /// <param name="stationSystem">Система станций</param>
-    /// <param name="entityManager">Менеджер сущностей</param>
-    /// <returns>true, если есть доступная станция</returns>
     public static bool HasValidTargetStation(StationSystem stationSystem, IEntityManager entityManager)
     {
-        if (_cacheValid)
-            return _cachedStation.IsValid();
-
         var stations = stationSystem.GetStations();
 
         foreach (var station in stations)
@@ -56,26 +40,13 @@ public static class StationEventHelper
             if (!entityManager.TryGetComponent<StationDataComponent>(station, out var data))
                 continue;
 
-            // Исключаем ЦентКом по StationPrototype
+            // Exclude CentComm by StationPrototype
             if (data.StationConfig != null && data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
                 continue;
 
-            _cachedStation = station;
-            _cacheValid = true;
             return true;
         }
 
-        _cachedStation = EntityUid.Invalid;
-        _cacheValid = true;
         return false;
-    }
-
-    /// <summary>
-    /// Сбрасывает кеш (вызывается при изменении списка станций)
-    /// </summary>
-    public static void InvalidateCache()
-    {
-        _cacheValid = false;
-        _cachedStation = EntityUid.Invalid;
     }
 }

--- a/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
+++ b/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
@@ -40,8 +40,12 @@ public static class StationEventHelper
             if (!entityManager.TryGetComponent<StationDataComponent>(station, out var data))
                 continue;
 
+            // Skip stations without config
+            if (data.StationConfig is null)
+                continue;
+
             // Exclude CentComm by StationPrototype
-            if (data.StationConfig != null && data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
+            if (data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
                 continue;
 
             return true;

--- a/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
+++ b/Content.Server/_Sunrise/StationEvents/StationEventHelper.cs
@@ -1,0 +1,81 @@
+using Content.Server.GameTicking;
+using Content.Server.Station.Components;
+using Content.Server.Station.Systems;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Station.Components;
+using Robust.Shared.GameObjects;
+
+namespace Content.Server._Sunrise.StationEvents;
+
+/// <summary>
+/// Вспомогательный класс для проверки доступности игровой станции (исключая ЦентКом)
+/// </summary>
+public static class StationEventHelper
+{
+    private static EntityUid _cachedStation = EntityUid.Invalid;
+    private static bool _cacheValid;
+
+    /// <summary>
+    /// Проверяет, нужно ли пропустить событие из-за отсутствия доступной игровой станции
+    /// </summary>
+    /// <param name="uid">Идентификатор события</param>
+    /// <param name="stationSystem">Система станций</param>
+    /// <param name="entityManager">Менеджер сущностей</param>
+    /// <param name="sawmill">Логгер</param>
+    /// <returns>true, если событие нужно пропустить</returns>
+    public static bool ShouldSkipEvent(
+        EntityUid uid,
+        StationSystem stationSystem,
+        IEntityManager entityManager,
+        ISawmill sawmill)
+    {
+        if (!HasValidTargetStation(stationSystem, entityManager))
+        {
+            sawmill.Info($"Skipping event {entityManager.ToPrettyString(uid)}: no valid target station (CentComm excluded)");
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Проверяет наличие доступной игровой станции (не ЦентКом)
+    /// </summary>
+    /// <param name="stationSystem">Система станций</param>
+    /// <param name="entityManager">Менеджер сущностей</param>
+    /// <returns>true, если есть доступная станция</returns>
+    public static bool HasValidTargetStation(StationSystem stationSystem, IEntityManager entityManager)
+    {
+        if (_cacheValid)
+            return _cachedStation.IsValid();
+
+        var stations = stationSystem.GetStations();
+
+        foreach (var station in stations)
+        {
+            if (!entityManager.TryGetComponent<StationDataComponent>(station, out var data))
+                continue;
+
+            // Исключаем ЦентКом по StationPrototype
+            if (data.StationConfig != null && data.StationConfig.StationPrototype == "NanotrasenCentralCommand")
+                continue;
+
+            _cachedStation = station;
+            _cacheValid = true;
+            return true;
+        }
+
+        _cachedStation = EntityUid.Invalid;
+        _cacheValid = true;
+        return false;
+    }
+
+    /// <summary>
+    /// Сбрасывает кеш (вызывается при изменении списка станций)
+    /// </summary>
+    public static void InvalidateCache()
+    {
+        _cacheValid = false;
+        _cachedStation = EntityUid.Invalid;
+    }
+}


### PR DESCRIPTION
## Краткое описание
Исправление бага, когда при запуске события VentFleshWorms на Станции ЦентКома появлялись черви плоти, что убивало пешек ЦК, которые находятся в агостах или не имеют прав и возможности защищаться из-за генератора пацифизма.

Так же исправлен известный баг о метеоритном рое, в который могла войти СЦК.

Исключена любая возможность на спавн иных ивентов в будущем.

## Ссылка на багрепорт/Предложение
#4362


**Changelog**

:cl: Coconut_Law
- fix: Событие со спавном червей плоти более не происходит на Станциях ЦентКома
- fix: Станции ЦентКома более не могут подвергнуться вхождению в рой метеоритов, что повышает ее безопасность максимально

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Summary

* **Исправления**
  * Улучшена проверка доступной игровой станции для станционных событий: события теперь запускаются только при наличии подходящей станции и не привязаны к ЦентКом.
  * Если подходящая станция не найдена, событие удаляется из очереди и не выполняет запуск/рассылку объявлений; логирование о нестарте выполняется корректно (с завершением по времени сохранено).

* **Новые возможности**
  * Добавлен единый помощник для поиска валидной станции.

* **Изменения оформления**
  * Приведены к единообразному виду параметры объявлений начала/окончания.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->