### PR TITLE
Тестовое отключение передачи жидкости у швабры при ударах

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -27,6 +27,7 @@
     solution: absorbed
     spillWhenThrown: false
     preventMelee: false
+    maxMeleeSpillAmount: 0 # Sunrise-Edit: не передаём жидкость при ударе мопом
   - type: DrainableSolution
     solution: absorbed
   - type: Wieldable


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
Тестовое отключение передачи жидкости у швабры при ударах

## Ссылка на багрепорт/Предложение
<img width="522" height="122" alt="image" src="https://github.com/user-attachments/assets/49667d00-4588-481b-a518-205e45d4fc8a" />


## Медиа (Видео/Скриншоты)

https://github.com/user-attachments/assets/820f3ea2-7d86-4529-a279-f0262f44f4b6



**Changelog**

:cl: Kinar_7

- tweak: Швабра уборщика больше не передаёт жидкости при ударах. Возможное решение проблемы гиб-швабр.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * При ударе мопом жидкость больше не разбрызгивается и не передаётся окружающим объектам.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->