### PR TITLE
попробуй открути

### DIFF
--- a/Resources/Locale/en-US/_prototypes/_sunrise/catalog/fills/items/toolboxes.ftl
+++ b/Resources/Locale/en-US/_prototypes/_sunrise/catalog/fills/items/toolboxes.ftl
@@ -1,6 +1,11 @@
-ent-ToolboxSyndicateFilledCoreExtraction = { ent-ToolboxSyndicate }
+ent-ToolboxSyndicateFilledCoreExtraction = { ent-SunriseToolboxSyndicate }
     .suffix = Filled, Core Extraction
-    .desc = { ent-ToolboxSyndicate.desc }
+    .desc = { ent-SunriseToolboxSyndicate.desc }
+
+ent-ToolboxSyndicateFilledRepair = { ent-SunriseToolboxSyndicate }
+    .suffix = Filled, Repair
+    .desc = { ent-SunriseToolboxSyndicate.desc }
+
 ent-ToolboxElectricalTurretPirateFilled = { ent-ToolboxElectricalTurretPirate }
     .suffix = Pirate, Turret, Filled
     .desc = { ent-ToolboxElectricalTurretPirate.desc }

--- a/Resources/Locale/en-US/_prototypes/_sunrise/entities/objects/tools/toolbox.ftl
+++ b/Resources/Locale/en-US/_prototypes/_sunrise/entities/objects/tools/toolbox.ftl
@@ -1,3 +1,10 @@
 ent-ToolboxElectricalTurretPirate = { ent-ToolboxElectricalTurret }
     .suffix = Pirate, Turret
     .desc = { ent-ToolboxElectricalTurret.desc }
+
+ent-SunriseToolboxSyndicate = blood-red toolbox
+    .desc = A blood-red toolbox packed with elite Syndicate tools.
+
+ent-SunriseToolboxSyndicateFilled = { ent-SunriseToolboxSyndicate }
+    .desc = { ent-SunriseToolboxSyndicate.desc }
+    .suffix = Filled

--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/catalog/fills/items/toolboxes.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/catalog/fills/items/toolboxes.ftl
@@ -1,8 +1,8 @@
-ent-ToolboxSyndicateFilledCoreExtraction = { ent-ToolboxSyndicate }
-    .desc = { ent-ToolboxSyndicate.desc }
+ent-ToolboxSyndicateFilledCoreExtraction = { ent-SunriseToolboxSyndicate }
+    .desc = { ent-SunriseToolboxSyndicate.desc }
     .suffix = Заполнен, Извлечение ядра
-ent-ToolboxSyndicateFilledRepair = { ent-ToolboxSyndicate }
-    .desc = { ent-ToolboxSyndicate.desc }
+ent-ToolboxSyndicateFilledRepair = { ent-SunriseToolboxSyndicate }
+    .desc = { ent-SunriseToolboxSyndicate.desc }
     .suffix = Заполнен, Ремонт мехов
 
 

--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/tools/toolbox.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/objects/tools/toolbox.ftl
@@ -1,3 +1,10 @@
 ent-ToolboxElectricalTurretPirate = { ent-ToolboxElectricalTurret }
     .suffix = Пират, Турель
     .desc = { ent-ToolboxElectricalTurret.desc }
+
+ent-SunriseToolboxSyndicate = кроваво-красный тулбокс
+    .desc = Кроваво-красный тулбокс, набитый элитными инструментами Синдиката.
+
+ent-SunriseToolboxSyndicateFilled = { ent-SunriseToolboxSyndicate }
+    .desc = { ent-SunriseToolboxSyndicate.desc }
+    .suffix = Заполненный

--- a/Resources/Maps/_Sunrise/planet_prison_old.yml
+++ b/Resources/Maps/_Sunrise/planet_prison_old.yml
@@ -56981,7 +56981,7 @@ entities:
         disableRefund: False
         costModifiersBySourceId: {}
       - id: UplinkPirateToolbox
-        productEntity: ToolboxSyndicateFilled
+        productEntity: SunriseToolboxSyndicateFilled
         name: uplink-toolbox-name
         discountCategory: null
         description: uplink-toolbox-desc
@@ -60171,7 +60171,7 @@ entities:
         disableRefund: False
         costModifiersBySourceId: {}
       - id: UplinkToolbox
-        productEntity: ToolboxSyndicateFilled
+        productEntity: SunriseToolboxSyndicateFilled
         name: uplink-toolbox-name
         discountCategory: rareDiscounts
         description: uplink-toolbox-desc

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -181,7 +181,7 @@
     - id: ClothingBackpackDuffelSyndicatePyjamaBundle
     - id: ClothingBeltMilitaryWebbing
     - id: ClothingShoesBootsCombatFilled
-    - id: ToolboxSyndicateFilled
+    - id: SunriseToolboxSyndicateFilled # Sunrise-Edit - замена официального ящика версией Sunrise
     - id: BalloonSyn
     - id: WeaponSniperMosin
       #Sunrise-start

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -181,7 +181,7 @@
     - id: ClothingBackpackDuffelSyndicatePyjamaBundle
     - id: ClothingBeltMilitaryWebbing
     - id: ClothingShoesBootsCombatFilled
-    - id: SunriseToolboxSyndicateFilled # Sunrise-Edit - замена официального ящика версией Sunrise
+    - id: SunriseToolboxSyndicateFilled # Sunrise-Edit
     - id: BalloonSyn
     - id: WeaponSniperMosin
       #Sunrise-start

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1221,7 +1221,7 @@
   id: UplinkToolbox
   name: uplink-toolbox-name
   description: uplink-toolbox-desc
-  productEntity: ToolboxSyndicateFilled
+  productEntity: SunriseToolboxSyndicateFilled # Sunrise-Edit - замена официального ящика версией Sunrise
   discountCategory: rareDiscounts
   discountDownTo:
     Telecrystal: 1

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1221,7 +1221,7 @@
   id: UplinkToolbox
   name: uplink-toolbox-name
   description: uplink-toolbox-desc
-  productEntity: SunriseToolboxSyndicateFilled # Sunrise-Edit - замена официального ящика версией Sunrise
+  productEntity: SunriseToolboxSyndicateFilled # Sunrise-Edit
   discountCategory: rareDiscounts
   discountDownTo:
     Telecrystal: 1

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -81,7 +81,7 @@
   equipment:
     pocket1: WeaponPistolViper
   inhand:
-    - ToolboxSyndicateFilled
+    - SunriseToolboxSyndicateFilled # Sunrise-Edit - замена официального ящика версией Sunrise
   storage:
     back:
     - SyndicateJawsOfLife

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -81,7 +81,7 @@
   equipment:
     pocket1: WeaponPistolViper
   inhand:
-    - SunriseToolboxSyndicateFilled # Sunrise-Edit - замена официального ящика версией Sunrise
+    - SunriseToolboxSyndicateFilled # Sunrise-Edit
   storage:
     back:
     - SyndicateJawsOfLife

--- a/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
@@ -71,3 +71,19 @@
           type: IcarusTerminalBoundUserInterface
     - type: ActivatableUI
       key: enum.IcarusTerminalUiKey.Key
+    - type: Anchorable
+      tool: Welding
+      delay: 60
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 30000
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound:
+            collection: GlassBreak
+        - !type:ChangeConstructionNodeBehavior
+          node: monitorBroken
+        - !type:DoActsBehavior
+          acts: ["Destruction"]

--- a/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
@@ -90,7 +90,7 @@
         - !type:ChangeConstructionNodeBehavior
           node: monitorBroken
         - !type:DoActsBehavior
-          acts: ["Destruction"]
+          acts: ["Breakage"]
 
 - type: constructionGraph
   id: IcarusTerminal

--- a/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
@@ -71,6 +71,10 @@
           type: IcarusTerminalBoundUserInterface
     - type: ActivatableUI
       key: enum.IcarusTerminalUiKey.Key
+    - type: Construction
+      graph: IcarusTerminal
+      node: icarusTerminal
+      deconstructionTarget: null
     - type: Anchorable
       tool: Welding
       delay: 120
@@ -87,3 +91,12 @@
           node: monitorBroken
         - !type:DoActsBehavior
           acts: ["Destruction"]
+
+- type: constructionGraph
+  id: IcarusTerminal
+  start: icarusTerminal
+  graph:
+    - node: icarusTerminal
+      entity: ComputerIcarus
+    - node: monitorBroken
+      entity: ComputerBroken

--- a/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
+++ b/Resources/Prototypes/_Sunrise/AssaultOps/terminal.yml
@@ -73,7 +73,7 @@
       key: enum.IcarusTerminalUiKey.Key
     - type: Anchorable
       tool: Welding
-      delay: 60
+      delay: 120
     - type: Destructible
       thresholds:
       - trigger:

--- a/Resources/Prototypes/_Sunrise/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/Fills/Items/toolboxes.yml
@@ -1,5 +1,25 @@
 - type: entity
-  parent: ToolboxSyndicate
+  parent: SunriseToolboxSyndicate
+  id: SunriseToolboxSyndicateFilled
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: Crowbar
+        - id: Wrench
+        - id: Screwdriver
+        - id: Wirecutter
+        - id: Welder
+        - id: Multitool
+        - id: ClothingHandsGlovesCombat
+        - id: ClothingMaskGasSyndicate
+  - type: StaticPrice
+    price: 1000
+
+- type: entity
+  parent: SunriseToolboxSyndicate
   id: ToolboxSyndicateFilledCoreExtraction
   suffix: Filled, Core Extraction
   components:
@@ -16,7 +36,7 @@
     price: 1500
 
 - type: entity
-  parent: ToolboxSyndicate
+  parent: SunriseToolboxSyndicate
   id: ToolboxSyndicateFilledRepair
   suffix: Filled, Repair
   components:

--- a/Resources/Prototypes/_Sunrise/Catalog/pirate_uplink_catalog.yml
+++ b/Resources/Prototypes/_Sunrise/Catalog/pirate_uplink_catalog.yml
@@ -1739,7 +1739,7 @@
   id: UplinkPirateToolbox
   name: uplink-toolbox-name
   description: uplink-toolbox-desc
-  productEntity: ToolboxSyndicateFilled
+  productEntity: SunriseToolboxSyndicateFilled
   cost:
     Doubloon: 4
   categories:

--- a/Resources/Prototypes/_Sunrise/Entities/Markers/Spawners/Random/contraband.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Markers/Spawners/Random/contraband.yml
@@ -20,7 +20,7 @@
         - ClothingOuterEVASuitSyndicate
         - ClothingHeadHelmetSyndicate
         - ClothingHeadHelmetSwatSyndicate
-        - ToolboxSyndicateFilled
+        - SunriseToolboxSyndicateFilled
         - ClothingOuterVestWeb
         - SyndicateJawsOfLife
         - HappyHonkNukie
@@ -58,7 +58,7 @@
         - ClothingNeckScarfStripedSyndieRed
         - ClothingShoesBootsWinterSyndicate
         - ClothingBeltSyndieHolster
-        - ToolboxSyndicate
+        - SunriseToolboxSyndicate
       chance: 0.8
       offset: 0.0
 

--- a/Resources/Prototypes/_Sunrise/Entities/Objects/Tools/toolbox.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Objects/Tools/toolbox.yml
@@ -37,3 +37,9 @@
               WeaponTurretPirateDisposable:
                 min: 1
                 max: 1
+
+- type: entity
+  parent: ToolboxSyndicate
+  id: SunriseToolboxSyndicate
+  name: blood-red toolbox
+  description: A blood-red toolbox packed with elite Syndicate tools.

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -1077,4 +1077,7 @@ JugSalineSunrise: JugSaline
 JugDexalinSunrise: null
 # 2026-06-29
 ClothingBackpackMessengerPirateBundleSKM24Scrap: CratePirateAkScrap
+# 2026-07-31
+ToolboxSyndicate: SunriseToolboxSyndicate
+ToolboxSyndicateFilled: SunriseToolboxSyndicateFilled
 # region Sunrise-End


### PR DESCRIPTION
Всякие утилизаторы, пилоты сбэу ломали ДО эту консоль превращая раунд в смешную нарезку экипажа вместо выполнения целей, периодически администраторы спавнили эту консоль вызывая недовольство у руиниров.
В связи с этим, хорошим решением будет усложнить процесс её поломки, заранее предвидя попытки спиздить консоль- сделал её отваривание длительным процессом

:cl: Fooksy2304
- tweak: Консоль «Икарус» получила 30 000 причин не ломаться и была приварена к полу, её невозможно открутить гаечным ключом, отваривание от пола займёт 2 минуты,  приваривание столько же, разобрать её невозможно
- tweak: кроваво-красный ящик для инструментов получил улучшенные версии инструментов,  также особый штурмовой шлем в виде кожурки от арбуза

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлен кроваво-красный ящик инструментов Синдиката и его заполненная версия.
  * Обновены магазины, наборы снаряжения и таблицы добычи для использования нового ящика.
  * Добавлена возможность закреплять сваркой и разрушать специальный компьютер.
* **Исправления**
  * Сохранена корректная работа существующих предметов после обновления прототипов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->