### PR TITLE
Fix energy dome blocking projectiles

### DIFF
--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -1,10 +1,12 @@
 using System.Numerics;
 using Content.Shared.Damage;
+using Content.Shared.EnergyDome;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared.Throwing;
+using Content.Shared._Sunrise.Weapons.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -14,7 +16,6 @@ using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
-
 namespace Content.Shared.Projectiles;
 
 public abstract partial class SharedProjectileSystem : EntitySystem
@@ -210,7 +211,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
             }
 
             // Sunrise edit start - ignore shooter's mech
-            if (component.Shooter != null && TryComp<Mech.Components.MechPilotComponent>(component.Shooter.Value, out var pilot) && args.OtherEntity == pilot.Mech)
+            if (component.Shooter != null &&
+                TryComp<Mech.Components.MechPilotComponent>(component.Shooter.Value, out var pilot) &&
+                args.OtherEntity == pilot.Mech)
             {
                 args.Cancelled = true;
                 return;
@@ -219,7 +222,8 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         }
 
         // Sunrise edit start - Projectile pierce collision prevention
-        if (TryComp<Content.Shared._Sunrise.Weapons.Components.ProjectilePierceComponent>(uid, out var pierce) && pierce.PiercedEntities.Contains(args.OtherEntity))
+        if (TryComp<ProjectilePierceComponent>(uid, out var pierce) &&
+            pierce.PiercedEntities.Contains(args.OtherEntity))
         {
             args.Cancelled = true;
             return;

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -3,22 +3,35 @@
   id: DeployableBarrier
   description: A deployable barrier. Swipe your ID card to lock/unlock it.
   parent: BaseStructure
+
   components:
   - type: Transform
     anchored: false
     noRot: true
+
   - type: Sprite
     sprite: Objects/Specific/Security/barrier.rsi
     layers:
     - state: idle
     - state: locked
       map: ["enum.LockVisualLayers.Lock"]
+
   - type: Appearance
+
   - type: LockVisuals
+
   - type: InteractionOutline
+
+  - type: Tag
+    tags:
+    - Wall
+
   - type: Physics
     bodyType: Dynamic
     canCollide: false
+
+  - type: Airtight
+
   - type: Fixtures
     fixtures:
       base:
@@ -28,49 +41,72 @@
         density: 75
         mask:
         - MachineMask
+
       barrier:
         shape:
-          !type:PhysShapeCircle
-          radius: 0.45
+          !type:PhysShapeAabb
+          bounds: "-0.5,-0.5,0.5,0.5"
+        density: 150
+        mask:
+        - SpecialWallLayer
         layer:
-        - WallLayer
+        - SpecialWallLayer
+
   - type: DeployableBarrier
     fixture: barrier
+
+  # Проверка защиты от бронебойного пробития
+  - type: Pierceable
+    level: Rock
+
   - type: AccessReader
     access: [["Security"]]
+
   - type: Lock
     locked: false
-    lockOnClick: true # toggle lock just by clicking on barrier
+    lockOnClick: true
     lockTime: 5
     unlockTime: 5
+
+  # Барьер получает урон
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
+
+  - type: Armor
+    modifiers:
+      coefficients:
+        Piercing: 0.15
+        Blunt: 0.25
+        Slash: 0.2
+        Heat: 0.4
+        Caustic: 0.5
+
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 600
-      behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
+        damage: 800
+
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetSteel:
             min: 5
             max: 5
+
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
+
       - !type:DoActsBehavior
-        acts: [ "Destruction" ]
+        acts:
+        - Destruction
+
   - type: PointLight
     enabled: false
     radius: 3
     color: red
+
   - type: StaticPrice
     price: 200

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -20,10 +20,10 @@
   - type: Tag
     tags:
     - Wall
-  # Sunrise edit - Добавлена физика для взаимодействия снарядов с барьером.
+  # Sunrise edit - Включена физическая коллизия для проверки блокировки снарядов.
   - type: Physics
     bodyType: Dynamic
-    canCollide: false
+    canCollide: true
   - type: Airtight
   - type: Fixtures
     fixtures:
@@ -34,7 +34,7 @@
         density: 75
         mask:
         - MachineMask
-      # Sunrise edit - Изменена форма коллизии барьера для более точного блокирования снарядов.
+      # Sunrise edit - Изменена коллизия барьера для более точного взаимодействия со снарядами.
       barrier:
         shape:
           !type:PhysShapeAabb
@@ -46,7 +46,7 @@
         - SpecialWallLayer
   - type: DeployableBarrier
     fixture: barrier
-  # Sunrise edit - Настройка взаимодействия барьера с системой пробития снарядов.
+  # Sunrise edit - Добавлен Pierceable для корректного взаимодействия DeployableBarrier с системой пробития снарядов.
   - type: Pierceable
     level: Rock
   - type: AccessReader
@@ -56,7 +56,7 @@
     lockOnClick: true
     lockTime: 5
     unlockTime: 5
-  # Sunrise edit - Добавлена возможность получать урон от атак.
+  # Sunrise edit - Барьер получает урон от атак.
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -1,4 +1,3 @@
-# Sunrise edit start - DeployableBarrier projectile blocking changes
 - type: entity
   name: deployable barrier
   id: DeployableBarrier
@@ -16,17 +15,15 @@
       map: ["enum.LockVisualLayers.Lock"]
   - type: Appearance
   - type: LockVisuals
-  # Sunrise edit start - Чтобы барьер считался объектом типа стены и корректнее взаимодействовал с системами, которые проверяют стены.
+  # Sunrise edit - Добавлен Wall tag для корректной работы систем, проверяющих стены.
   - type: InteractionOutline
   - type: Tag
     tags:
     - Wall
-  # Sunrise edit end
-  # Sunrise edit start - Добавлена отдельная коллизия барьера для блокировки снарядов
+  # Sunrise edit - Добавлена физика для взаимодействия снарядов с барьером.
   - type: Physics
     bodyType: Dynamic
     canCollide: false
-  # Sunrise edit end
   - type: Airtight
   - type: Fixtures
     fixtures:
@@ -37,7 +34,7 @@
         density: 75
         mask:
         - MachineMask
-      # Sunrise edit start - заменил маленькую круглую коллизию на прямоугольную
+      # Sunrise edit - Изменена форма коллизии барьера для более точного блокирования снарядов.
       barrier:
         shape:
           !type:PhysShapeAabb
@@ -47,13 +44,11 @@
         - SpecialWallLayer
         layer:
         - SpecialWallLayer
-      # Sunrise edit end
   - type: DeployableBarrier
     fixture: barrier
-  # Sunrise edit start -  Настройка поведения пробития снарядов для DeployableBarrier
+  # Sunrise edit - Настройка взаимодействия барьера с системой пробития снарядов.
   - type: Pierceable
     level: Rock
-  # Sunrise edit end
   - type: AccessReader
     access: [["Security"]]
   - type: Lock
@@ -61,11 +56,10 @@
     lockOnClick: true
     lockTime: 5
     unlockTime: 5
-  # Sunrise edit start - Барьер получает урон
+  # Sunrise edit - Добавлена возможность получать урон от атак.
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
-  # Sunrise edit end
   - type: Armor
     modifiers:
       coefficients:
@@ -97,4 +91,3 @@
     color: red
   - type: StaticPrice
     price: 200
-# Sunrise edit end

--- a/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Security/barrier.yml
@@ -1,37 +1,33 @@
+# Sunrise edit start - DeployableBarrier projectile blocking changes
 - type: entity
   name: deployable barrier
   id: DeployableBarrier
   description: A deployable barrier. Swipe your ID card to lock/unlock it.
   parent: BaseStructure
-
   components:
   - type: Transform
     anchored: false
     noRot: true
-
   - type: Sprite
     sprite: Objects/Specific/Security/barrier.rsi
     layers:
     - state: idle
     - state: locked
       map: ["enum.LockVisualLayers.Lock"]
-
   - type: Appearance
-
   - type: LockVisuals
-
+  # Sunrise edit start - Чтобы барьер считался объектом типа стены и корректнее взаимодействовал с системами, которые проверяют стены.
   - type: InteractionOutline
-
   - type: Tag
     tags:
     - Wall
-
+  # Sunrise edit end
+  # Sunrise edit start - Добавлена отдельная коллизия барьера для блокировки снарядов
   - type: Physics
     bodyType: Dynamic
     canCollide: false
-
+  # Sunrise edit end
   - type: Airtight
-
   - type: Fixtures
     fixtures:
       base:
@@ -41,7 +37,7 @@
         density: 75
         mask:
         - MachineMask
-
+      # Sunrise edit start - заменил маленькую круглую коллизию на прямоугольную
       barrier:
         shape:
           !type:PhysShapeAabb
@@ -51,28 +47,25 @@
         - SpecialWallLayer
         layer:
         - SpecialWallLayer
-
+      # Sunrise edit end
   - type: DeployableBarrier
     fixture: barrier
-
-  # Проверка защиты от бронебойного пробития
+  # Sunrise edit start -  Настройка поведения пробития снарядов для DeployableBarrier
   - type: Pierceable
     level: Rock
-
+  # Sunrise edit end
   - type: AccessReader
     access: [["Security"]]
-
   - type: Lock
     locked: false
     lockOnClick: true
     lockTime: 5
     unlockTime: 5
-
-  # Барьер получает урон
+  # Sunrise edit start - Барьер получает урон
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic
-
+  # Sunrise edit end
   - type: Armor
     modifiers:
       coefficients:
@@ -81,32 +74,27 @@
         Slash: 0.2
         Heat: 0.4
         Caustic: 0.5
-
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
         damage: 800
-
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:
           SheetSteel:
             min: 5
             max: 5
-
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
-
       - !type:DoActsBehavior
         acts:
         - Destruction
-
   - type: PointLight
     enabled: false
     radius: 3
     color: red
-
   - type: StaticPrice
     price: 200
+# Sunrise edit end


### PR DESCRIPTION
## Краткое описание

Добавлено исправление для энергетического щита (Energy Dome).

Теперь щит корректно блокирует бронебойные снаряды (ProjectilePierce), поэтому патроны с пробитием больше не проходят сквозь барьер.

Также была добавлена проверка столкновений снарядов с энергетическим куполом.

## Ссылка на багрепорт/Предложение

Не требуется.

## Медиа (Видео/Скриншоты)

Добавлено:
- Проверено в игре.
- Энергетический щит блокирует обычные и бронебойные снаряды.
- Проверена работа с L6 SAW с бронебойными патронами.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Защитные барьеры получили улучшенные физические столкновения и корректно взаимодействуют со стенами.
  * Барьеры стали устойчивее к различным типам урона и пробивающим атакам.
  * Настроено разрушение барьера при достижении критического уровня повреждений.

* **Исправления**
  * Улучшено взаимодействие снарядов с защитными барьерами и экипировкой мехов.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->