### PR TITLE
[FIX] Admin following via ghost

### DIFF
--- a/Content.Shared/Follower/FollowerSystem.cs
+++ b/Content.Shared/Follower/FollowerSystem.cs
@@ -33,6 +33,7 @@ public sealed class FollowerSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
     [Dependency] private readonly INetManager _netMan = default!;
     [Dependency] private readonly ISharedAdminManager _adminManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!; //* SUNRISE ADD
 
     private static readonly ProtoId<TagPrototype> ForceableFollowTag = "ForceableFollow";
     private static readonly ProtoId<TagPrototype> PreventGhostnadoWarpTag = "NotGhostnadoWarpable";
@@ -184,7 +185,9 @@ public sealed class FollowerSystem : EntitySystem
     /// <param name="entity">The entity to be followed</param>
     public void StartFollowingEntity(EntityUid follower, EntityUid entity)
     {
-        if (follower == entity || TerminatingOrDeleted(entity))
+        if (follower == entity ||
+            TerminatingOrDeleted(entity) ||
+            !_entityManager.HasComponent<GhostComponent>(follower)) //* SUNRISE ADD - ADMIN FOLLOW BUGFIX
             return;
 
         // No recursion for you


### PR DESCRIPTION
<!-- Текст в стрелочках является комментариями — они не будут видны в вашем PR. -->

## Краткое описание
Устранение бага, при котором администратор мог начать следовать за игроком находясь в собственном игровом персонаже.

**Changelog**

:cl: Mazuta
- fix: Устранён баг, при котором администратор мог следовать за игроком находясь в игровом персонаже


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Следование теперь запускается только для сущностей-призраков.
  * Попытки начать следование другими типами сущностей автоматически прекращаются.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->