### PR TITLE
Исправление валидатора чейнджлога для старых PR

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout trusted parser
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
           sparse-checkout: |
             .github/PULL_REQUEST_TEMPLATE.md

--- a/Tools/_sunrise/changelog/test_changelog_actions.py
+++ b/Tools/_sunrise/changelog/test_changelog_actions.py
@@ -1820,7 +1820,7 @@ class ChangelogActionsTests(unittest.TestCase):
         self.assertIn("statuses: write", workflow)
         self.assertIn("group: validate-changelog-${{ github.event.pull_request.number }}", workflow)
         self.assertIn("cancel-in-progress: true", workflow)
-        self.assertIn("ref: ${{ github.event.pull_request.base.sha }}", workflow)
+        self.assertIn("ref: ${{ github.event.pull_request.base.ref }}", workflow)
         self.assertNotIn("ref: ${{ github.event.pull_request.head.sha }}", workflow)
         self.assertNotIn("github.event.pull_request.body", workflow)
         self.assertIn("persist-credentials: false", workflow)


### PR DESCRIPTION
## Причина

Старые PR сохраняют SHA базовой ветки на момент последней синхронизации. После обновления валидатора workflow мог взять старый `changelog_actions.py`, который не знает аргумент `--validate-only`.

На PR #4732 это привело к ошибке `unrecognized arguments: --validate-only`.

## Исправление

Доверенный парсер берётся из актуальной целевой ветки PR (`base.ref`), а не из сохранённого старого SHA. Код из ветки автора PR по-прежнему не исполняется.

## Проверка

- `python Tools/_sunrise/changelog/test_changelog_actions.py` — 74 теста успешно.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Обновлена проверка изменений в pull request: теперь корректно используется базовая ветка вместо фиксированного коммита.
  * Повышена надежность автоматической проверки формата журнала изменений.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->