### PR TITLE
[Заказ] Выбор нимба и рогов для милир  / переоткрытие 

### DIFF
--- a/Content.Client/Body/VisualBodySystem.cs
+++ b/Content.Client/Body/VisualBodySystem.cs
@@ -217,6 +217,7 @@ public sealed partial class VisualBodySystem : SharedVisualBodySystem
         }
         ent.Comp.AppliedMarkings = applied;
         ApplySunriseMarkingEffects(ent, target); // Sunrise-Edit
+        RaiseSunriseMarkingsUpdated(target); // Sunrise-Edit - синхронизация систем, зависящих от markings
     }
 
     private void RemoveMarkings(Entity<VisualOrganMarkingsComponent> ent, EntityUid target)

--- a/Content.Client/_Sunrise/Body/VisualBodySystem.Markings.cs
+++ b/Content.Client/_Sunrise/Body/VisualBodySystem.Markings.cs
@@ -133,6 +133,12 @@ public sealed partial class VisualBodySystem
             : layer;
     }
 
+    private void RaiseSunriseMarkingsUpdated(EntityUid target)
+    {
+        var ev = new SunriseMarkingsUpdatedEvent();
+        RaiseLocalEvent(target, ref ev);
+    }
+
     private bool HasSunriseAliasedMarkingLayer(
         Entity<VisualOrganMarkingsComponent> ent,
         HumanoidVisualLayers visualLayer)
@@ -249,3 +255,9 @@ public sealed partial class VisualBodySystem
         return markings.MarkingsDisplacement.GetValueOrDefault(layer);
     }
 }
+
+/// <summary>
+/// Вызывается на теле после перестроения клиентских слоёв markings.
+/// </summary>
+[ByRefEvent]
+public readonly record struct SunriseMarkingsUpdatedEvent;

--- a/Content.Client/_Sunrise/Lobby/UI/HumanoidProfileEditor.Sponsors.cs
+++ b/Content.Client/_Sunrise/Lobby/UI/HumanoidProfileEditor.Sponsors.cs
@@ -19,7 +19,9 @@ public sealed partial class HumanoidProfileEditor
 
         return _prototypeManager.EnumeratePrototypes<SpeciesPrototype>()
             .Where(species => species.RoundStart &&
-                (!species.SponsorOnly || sponsorPrototypes.Contains(species.ID)));
+                (_sponsorsMgr is null ||
+                    !species.SponsorOnly ||
+                    sponsorPrototypes.Contains(species.ID)));
     }
 
     private FlavorText.FlavorText CreateSunriseFlavorText()

--- a/Content.Client/_Sunrise/Mood/MoodVisualizerSystem.cs
+++ b/Content.Client/_Sunrise/Mood/MoodVisualizerSystem.cs
@@ -17,7 +17,7 @@ namespace Content.Client._Sunrise.Mood;
 public sealed class MoodVisualizerSystem : VisualizerSystem<MoodVisualsComponent>
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
-    [Dependency] private readonly SunriseHumanoidBodySystem _sunriseBody = default!;
+    [Dependency] private readonly SunriseHumanoidBodySystem _body = default!;
 
     public override void Initialize()
     {
@@ -63,10 +63,7 @@ public sealed class MoodVisualizerSystem : VisualizerSystem<MoodVisualsComponent
         if (HasComp<PentagramComponent>(ent) && HasComp<WingToggleComponent>(ent))
             return false;
 
-        if (!AppearanceSystem.TryGetData<MoodThreshold>(ent, MoodVisuals.CurrentMoodThreshold, out var moodThreshold, appearance))
-            return ent.Comp.VisibleWithoutMood;
-
-        return ent.Comp.MoodStates.TryGetValue(moodThreshold, out state);
+        return !AppearanceSystem.TryGetData<MoodThreshold>(ent, MoodVisuals.CurrentMoodThreshold, out var moodThreshold, appearance) ? ent.Comp.VisibleWithoutMood : ent.Comp.MoodStates.TryGetValue(moodThreshold, out state);
     }
 
     private void UpdateMoodMarking(
@@ -80,7 +77,7 @@ public sealed class MoodVisualizerSystem : VisualizerSystem<MoodVisualsComponent
 
         Entity<SpriteComponent> spriteEnt = (ent, sprite);
         var nullableSpriteEnt = spriteEnt.AsNullable();
-        var visible = moodVisible && _sunriseBody.IsLayerVisible(ent, prototype.BodyPart);
+        var visible = moodVisible && _body.IsLayerVisible(ent, prototype.BodyPart);
         foreach (var markingSprite in prototype.Sprites)
         {
             if (markingSprite is not SpriteSpecifier.Rsi rsi)

--- a/Content.Client/_Sunrise/Mood/MoodVisualizerSystem.cs
+++ b/Content.Client/_Sunrise/Mood/MoodVisualizerSystem.cs
@@ -1,93 +1,98 @@
 using Content.Client._Sunrise.BloodCult;
+using Content.Client.Body;
 using Content.Shared._Sunrise.Abilities.Milira;
+using Content.Shared._Sunrise.Humanoid;
 using Content.Shared._Sunrise.Mood;
+using Content.Shared.Body;
+using Content.Shared.Humanoid;
 using Robust.Client.GameObjects;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Client._Sunrise.Mood;
 
 /// <summary>
-/// Обрабатывает отображение эффектов настроения на сущностях с компонентом настроения.
+/// Применяет состояния настроения к настроенным слоям markings гуманоида.
 /// </summary>
 public sealed class MoodVisualizerSystem : VisualizerSystem<MoodVisualsComponent>
 {
-    [Dependency] private readonly SpriteSystem _spriteSystem = default!;
-    [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SunriseHumanoidBodySystem _sunriseBody = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<MoodVisualsComponent, ComponentInit>(OnComponentInit);
-        SubscribeLocalEvent<MoodVisualsComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<MoodVisualsComponent, ComponentStartup>(OnStartup);
+        SubscribeLocalEvent<MoodVisualsComponent, SunriseMarkingsUpdatedEvent>(OnMarkingsUpdated);
+        SubscribeLocalEvent<MoodVisualsComponent, HumanoidLayerVisibilityChangedEvent>(OnLayerVisibilityChanged,
+            after: [typeof(BodySystem)]);
     }
 
-    private void OnShutdown(Entity<MoodVisualsComponent> ent, ref ComponentShutdown args)
-    {
-        if (!TryComp<SpriteComponent>(ent.Owner, out var sprite))
-            return;
-
-        if (_spriteSystem.LayerMapTryGet((ent.Owner, sprite), MoodVisualLayers.Mood, out var layer, false))
-            _spriteSystem.RemoveLayer((ent.Owner, sprite), layer);
-    }
-
-    private void OnComponentInit(Entity<MoodVisualsComponent> ent, ref ComponentInit args)
-    {
-        if (!TryComp<SpriteComponent>(ent.Owner, out var sprite))
-            return;
-
-        _spriteSystem.LayerMapReserve((ent.Owner, sprite), MoodVisualLayers.Mood);
-        _spriteSystem.LayerSetVisible((ent.Owner, sprite), MoodVisualLayers.Mood, false);
-        sprite.LayerSetShader(MoodVisualLayers.Mood, "unshaded");
-        if (ent.Comp.Sprite != null)
-            _spriteSystem.LayerSetSprite((ent.Owner, sprite), MoodVisualLayers.Mood, ent.Comp.Sprite);
-
-        if (TryComp<AppearanceComponent>(ent.Owner, out var appearance))
-            UpdateAppearance(ent, sprite, appearance);
-    }
+    private void OnStartup(Entity<MoodVisualsComponent> ent, ref ComponentStartup args)
+        => UpdateAppearance(ent);
 
     protected override void OnAppearanceChange(EntityUid uid, MoodVisualsComponent component, ref AppearanceChangeEvent args)
+        => UpdateAppearance((uid, component), args.Component, args.Sprite);
+
+    private void OnMarkingsUpdated(Entity<MoodVisualsComponent> ent, ref SunriseMarkingsUpdatedEvent args)
+        => UpdateAppearance(ent);
+
+    private void OnLayerVisibilityChanged(Entity<MoodVisualsComponent> ent, ref HumanoidLayerVisibilityChangedEvent args)
+        => UpdateAppearance(ent);
+
+    private void UpdateAppearance(
+        Entity<MoodVisualsComponent> ent,
+        AppearanceComponent? appearance = null,
+        SpriteComponent? sprite = null)
     {
-        if (args.Sprite != null)
-            UpdateAppearance((uid, component), args.Sprite, args.Component);
+        if (!Resolve(ent.Owner, ref appearance, ref sprite, false))
+            return;
+
+        var visible = TryGetMoodState(ent, appearance, out var state);
+        UpdateMoodMarking(ent, sprite, visible, state);
     }
 
-    private bool ShouldHideMoodVisuals(Entity<MoodVisualsComponent> ent)
+    private bool TryGetMoodState(
+        Entity<MoodVisualsComponent> ent,
+        AppearanceComponent appearance,
+        out string? state)
     {
-        return HasComp<PentagramComponent>(ent) && HasComp<WingToggleComponent>(ent);
+        state = null;
+
+        if (HasComp<PentagramComponent>(ent) && HasComp<WingToggleComponent>(ent))
+            return false;
+
+        if (!AppearanceSystem.TryGetData<MoodThreshold>(ent, MoodVisuals.CurrentMoodThreshold, out var moodThreshold, appearance))
+            return ent.Comp.VisibleWithoutMood;
+
+        return ent.Comp.MoodStates.TryGetValue(moodThreshold, out state);
     }
 
-    private void UpdateAppearance(Entity<MoodVisualsComponent> ent, SpriteComponent sprite, AppearanceComponent appearance)
+    private void UpdateMoodMarking(
+        Entity<MoodVisualsComponent> ent,
+        SpriteComponent sprite,
+        bool moodVisible,
+        string? state)
     {
-        if (!_spriteSystem.LayerMapTryGet((ent, sprite), MoodVisualLayers.Mood, out var index, false))
+        if (!_prototype.TryIndex(ent.Comp.Marking, out var prototype))
             return;
 
-        if (ShouldHideMoodVisuals(ent))
+        Entity<SpriteComponent> spriteEnt = (ent, sprite);
+        var nullableSpriteEnt = spriteEnt.AsNullable();
+        var visible = moodVisible && _sunriseBody.IsLayerVisible(ent, prototype.BodyPart);
+        foreach (var markingSprite in prototype.Sprites)
         {
-            _spriteSystem.LayerSetVisible((ent, sprite), index, false);
-            return;
-        }
+            if (markingSprite is not SpriteSpecifier.Rsi rsi)
+                continue;
 
-        if (!_appearanceSystem.TryGetData<MoodThreshold>(ent.Owner, MoodVisuals.CurrentMoodThreshold, out var moodThreshold, appearance))
-        {
-            _spriteSystem.LayerSetVisible((ent.Owner, sprite), index, false);
-            return;
-        }
+            var layerKey = $"{prototype.ID}-{rsi.RsiState}";
+            if (!SpriteSystem.LayerMapTryGet(nullableSpriteEnt, layerKey, out var layer, false))
+                continue;
 
-        // Проверяем, есть ли состояние спрайта для этого порога настроения
-        if (!ent.Comp.MoodStates.TryGetValue(moodThreshold, out var state))
-        {
-            _spriteSystem.LayerSetVisible((ent.Owner, sprite), index, false);
-            return;
+            sprite.LayerSetShader(layer, "unshaded");
+            SpriteSystem.LayerSetVisible(nullableSpriteEnt, layer, visible);
+            SpriteSystem.LayerSetRsiState(nullableSpriteEnt, layer, state ?? rsi.RsiState);
         }
-
-        // Показываем слой спрайта и устанавливаем состояние
-        _spriteSystem.LayerSetVisible((ent.Owner, sprite), index, true);
-        _spriteSystem.LayerSetRsiState((ent.Owner, sprite), index, state);
     }
-}
-
-public enum MoodVisualLayers : byte
-{
-    Mood
 }

--- a/Content.Shared/Mood/MoodVisualsComponent.cs
+++ b/Content.Shared/Mood/MoodVisualsComponent.cs
@@ -1,24 +1,29 @@
-using Content.Shared._Sunrise.Mood;
+using Content.Shared.Humanoid.Markings;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Utility;
 
 namespace Content.Shared._Sunrise.Mood;
 
 /// <summary>
-/// Устанавливает, какой спрайт RSI используется для отображения визуальных эффектов настроения и какое состояние использовать в зависимости от текущего порога настроения.
+/// Настраивает markings, состояние RSI которых зависит от настроения сущности.
 /// </summary>
 [RegisterComponent]
 public sealed partial class MoodVisualsComponent : Component
 {
     /// <summary>
-    /// Спрайт RSI, используемый для визуализации настроения.
+    /// Marking, на который влияет визуализация настроения.
     /// </summary>
-    [DataField]
-    public SpriteSpecifier? Sprite;
+    [DataField(required: true)]
+    public ProtoId<MarkingPrototype> Marking;
 
     /// <summary>
-    /// Словарь, сопоставляющий пороги настроения с состояниями спрайта.
-    /// Если порог отсутствует в этом словаре, спрайт для этого порога отображаться не будет.
+    /// Должны ли настроенные markings отображаться до появления данных о настроении.
+    /// </summary>
+    [DataField]
+    public bool VisibleWithoutMood;
+
+    /// <summary>
+    /// Сопоставляет пороги настроения с состояниями RSI.
+    /// Если порог отсутствует, настроенные markings скрываются.
     /// </summary>
     [DataField]
     public Dictionary<MoodThreshold, string> MoodStates = new();

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -495,7 +495,9 @@ namespace Content.Shared.Preferences
 
             if (!prototypeManager.TryIndex(Species, out var speciesPrototype) ||
                 !speciesPrototype.RoundStart ||
-                speciesPrototype.SponsorOnly && !sponsorPrototypes.Contains(Species.Id)) // Sunrise-Edit
+                (collection.TryResolveType<ISharedSponsorsManager>(out _) &&
+                    speciesPrototype.SponsorOnly &&
+                    !sponsorPrototypes.Contains(Species.Id))) // Sunrise-Edit
             {
                 Species = HumanoidCharacterProfile.DefaultSpecies;
                 speciesPrototype = prototypeManager.Index(Species);

--- a/Resources/Locale/en-US/_prototypes/_sunrise/entities/mobs/customization/markings/milira_mood.ftl
+++ b/Resources/Locale/en-US/_prototypes/_sunrise/entities/mobs/customization/markings/milira_mood.ftl
@@ -1,0 +1,1 @@
+marking-SunriseMiliraHalo = halo

--- a/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/mobs/customization/markings/milira_mood.ftl
+++ b/Resources/Locale/ru-RU/_prototypes/_sunrise/entities/mobs/customization/markings/milira_mood.ftl
@@ -1,0 +1,1 @@
+marking-SunriseMiliraHalo = нимб

--- a/Resources/Prototypes/_Sunrise/Body/Parts/milira.yml
+++ b/Resources/Prototypes/_Sunrise/Body/Parts/milira.yml
@@ -43,6 +43,7 @@
     hideableLayers:
     - enum.HumanoidVisualLayers.Hair
     - enum.HumanoidVisualLayers.FacialHair
+    - enum.HumanoidVisualLayers.HeadSide
     - enum.HumanoidVisualLayers.HeadTop
   - type: Extractable
     juiceSolution:

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/demon.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/demon.yml
@@ -71,7 +71,7 @@
 - type: marking
   id: DemonCowHorns
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: cow_horns
@@ -79,7 +79,7 @@
 - type: marking
   id: DemonHornsDeer
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: deer_antlers_horns
@@ -87,7 +87,7 @@
 - type: marking
   id: DemonHornsSmall
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: small_horns
@@ -150,7 +150,7 @@
 - type: marking
   id: DemonHornsDouble
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_double
@@ -158,7 +158,7 @@
 - type: marking
   id: DemonHornsDoubleAlt
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_double_alt
@@ -166,7 +166,7 @@
 - type: marking
   id: DemonHornsNarrow
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_narrow
@@ -174,7 +174,7 @@
 - type: marking
   id: DemonHornsGoatee
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_goatee
@@ -182,7 +182,7 @@
 - type: marking
   id: DemonHornsGoateeAlt
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_goatee_alt
@@ -190,7 +190,7 @@
 - type: marking
   id: DemonHornsSharp
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_sharp
@@ -198,7 +198,7 @@
 - type: marking
   id: DemonHornsGrowths
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_growths
@@ -206,7 +206,7 @@
 - type: marking
   id: DemonHornsBrokenOne
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_broken_one
@@ -214,7 +214,7 @@
 - type: marking
   id: DemonHornsStout
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_stout
@@ -222,7 +222,7 @@
 - type: marking
   id: DemonHornsEnormous
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_enormous
@@ -230,7 +230,7 @@
 - type: marking
   id: DemonHornsScythe
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_scythe
@@ -238,7 +238,7 @@
 - type: marking
   id: DemonHornsTapering
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_tapering
@@ -246,7 +246,7 @@
 - type: marking
   id: DemonHornsDirectional
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_directional
@@ -254,7 +254,7 @@
 - type: marking
   id: DemonHornsThick
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_thick
@@ -262,7 +262,7 @@
 - type: marking
   id: DemonHornsSickle
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_sickle
@@ -270,7 +270,7 @@
 - type: marking
   id: DemonHornsSlim
   bodyPart: HeadTop
-  groupWhitelist: [ Demon ]
+  groupWhitelist: [ Demon, Milira ]
   sprites:
   - sprite: _Sunrise/Mobs/Species/Demon/markings.rsi
     state: horns_slim

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/milira_ears.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/milira_ears.yml
@@ -1,6 +1,6 @@
 - type: marking
   id: MiliraEars
-  bodyPart: HeadTop
+  bodyPart: HeadSide
   forcedColoring: true
   groupWhitelist: [ Milira ]
   sprites:
@@ -9,7 +9,7 @@
 
 - type: marking
   id: MiliraEarsShortened
-  bodyPart: HeadTop
+  bodyPart: HeadSide
   forcedColoring: true
   groupWhitelist: [ Milira ]
   sprites:
@@ -18,7 +18,7 @@
 
 - type: marking
   id: MiliraEarsStraight
-  bodyPart: HeadTop
+  bodyPart: HeadSide
   forcedColoring: true
   groupWhitelist: [ Milira ]
   sprites:
@@ -27,7 +27,7 @@
 
 - type: marking
   id: MiliraEarsCurved
-  bodyPart: HeadTop
+  bodyPart: HeadSide
   forcedColoring: true
   groupWhitelist: [ Milira ]
   sprites:
@@ -36,7 +36,7 @@
 
 - type: marking
   id: MiliraEarsCurvedShortened
-  bodyPart: HeadTop
+  bodyPart: HeadSide
   forcedColoring: true
   groupWhitelist: [ Milira ]
   sprites:

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/milira_mood.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Customization/Markings/milira_mood.yml
@@ -1,0 +1,13 @@
+- type: marking
+  id: SunriseMiliraHalo
+  bodyPart: HeadTop
+  groupWhitelist: [ Milira ]
+  forcedColoring: true
+  coloring:
+    default:
+      type:
+        !type:SimpleColoring
+          color: "#FFFFFF"
+  sprites:
+  - sprite: _Sunrise/Mobs/Effects/Milira/mood.rsi
+    state: mood_neutral

--- a/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/milira.yml
+++ b/Resources/Prototypes/_Sunrise/Entities/Mobs/Species/milira.yml
@@ -36,9 +36,7 @@
   - type: Interactions
   - type: WingToggle
   - type: MoodVisuals
-    sprite:
-      sprite: _Sunrise/Mobs/Effects/Milira/mood.rsi
-      state: mood_neutral
+    marking: SunriseMiliraHalo
     moodStates:
       Insane: mood_bad
       Horrible: mood_bad
@@ -111,7 +109,5 @@
   - type: SunriseHumanoidProfile
   - type: SunriseHumanoidBaseLayers
   - type: MoodVisuals
-    sprite:
-      sprite: _Sunrise/Mobs/Effects/Milira/mood.rsi
-      state: mood_neutral
-
+    marking: SunriseMiliraHalo
+    visibleWithoutMood: true

--- a/Resources/Prototypes/_Sunrise/Species/milira.yml
+++ b/Resources/Prototypes/_Sunrise/Species/milira.yml
@@ -92,6 +92,10 @@
     enum.HumanoidVisualLayers.HeadTop:
       limit: 1
       required: true
+      default: [ SunriseMiliraHalo ]
+    enum.HumanoidVisualLayers.HeadSide:
+      limit: 1
+      required: true
       default: [ MiliraEars ]
     enum.HumanoidVisualLayers.Chest:
       limit: 1


### PR DESCRIPTION
## Краткое описание

Добавлен выбор внешности для милир между нимбом и различными видами рогов (Роги от аркан)
Важно -> специально сделано так, чтобы нельзя было выбрать рога + нимб.

Сделал небольшой cleanup в  `MoodVisualizerSystem.cs`. Полный cleanup в этом ПРе делать не буду.

ДОПОЛНИТЕЛЬНО:
Также исправлено сохранение персонажей спонсорских рас в сборках без подключённой системы спонсоров. Невозможно было сохранить персонажа на спонсорской расе на тестовом сервере. Исправил проверком есть ли спонсоркий менеджер.

## Ссылка на багрепорт/Предложение

https://discord.com/channels/1499823476360613898/1512507715925053553

## Медиа
Скриншоты выбора нимба и рогов
<img width="268" height="321" alt="screenshot-2026-07-10_21-03-39" src="https://github.com/user-attachments/assets/05f6b1c7-9840-46f4-8020-5857b9704e5f" />
<img width="270" height="287" alt="screenshot-2026-07-10_21-04-38" src="https://github.com/user-attachments/assets/a02aab04-07c1-44ef-9335-0407f6e3f5ba" />
<img width="330" height="342" alt="screenshot-2026-07-10_21-05-33" src="https://github.com/user-attachments/assets/e8c63e30-a224-4d30-a354-0f008a2237b9" />

**Changelog**

:cl: Orvex07
- add: Для милир добавлен выбор между нимбом и различными видами рогов.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Новые возможности
* Визуализация настроения теперь использует пользовательские маркировки и обновляется при изменении внешности.
* Для Milira добавлена маркировка «Нимб», отображаемая даже без данных о настроении.
* Для Milira добавлены отдельные слоты для ушных и специальных маркировок.
* Демонические рога стали доступны для настройки персонажей Milira.

## Исправления
* Улучшена проверка доступности спонсорских видов при загрузке профиля персонажа.

## Локализация
* Добавлены названия маркировки «Нимб» на русском и английском языках.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->